### PR TITLE
Fix install instructions

### DIFF
--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -15,4 +15,4 @@ requirements.
 .. code-block:: bash
 
     sudo apt-get install mingw-w64 python-pip
-    sudo pip install sphinx docutils pyyaml
+    sudo pip2 install sphinx docutils pyyaml


### PR DESCRIPTION
the python-pip package installs pip as pip2 now on Ubuntu Source: just ran an install.